### PR TITLE
Swift4 api addition

### DIFF
--- a/DaisyChain.xcodeproj/project.pbxproj
+++ b/DaisyChain.xcodeproj/project.pbxproj
@@ -152,10 +152,12 @@
 				TargetAttributes = {
 					7BA6A0361C1F8C1000A41460 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0830;
 					};
 					7BA6A0401C1F8C1000A41460 = {
 						CreatedOnToolsVersion = 7.2;
 						DevelopmentTeam = W4KHXBA29T;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -329,6 +331,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -349,6 +352,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.alikaragoz.DaisyChain;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -360,16 +364,19 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alikaragoz.DaisyChainTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
 		7BA6A0501C1F8C1000A41460 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DaisyChainTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alikaragoz.DaisyChainTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/DaisyChain/DaisyChain.swift
+++ b/DaisyChain/DaisyChain.swift
@@ -71,13 +71,15 @@ public class DaisyChain {
      - parameter animations: A block object containing the changes to commit to the views. This is  where you
                              programmatically change any animatable properties of the views in your view hierarchy. This
                              block takes no parameters and has no return value. This parameter must not be `NULL`.
+     - returns:              The current DaisyChain instance.
     */
-    public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void) {
+    @discardableResult public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void) -> DaisyChain {
         performAndWait {
             UIView.animate(withDuration: duration, animations: animations, completion: { finished -> Void in
                 self.resume(nil, finished: finished)
             })
         }
+        return self
     }
   
     /**
@@ -94,13 +96,15 @@ public class DaisyChain {
                              actually finished before the completion handler was called. If the duration of the animation
                              is `0`, this block is performed at the beginning of the next run loop cycle. This parameter
                              may be `NULL`.
+     - returns:              The current DaisyChain instance.
     */
-    public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+    @discardableResult public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) -> DaisyChain {
         performAndWait {
             UIView.animate(withDuration: duration, animations: animations, completion: { finished -> Void in
                 self.resume(completion, finished: finished)
             })
         }
+        return self
     }
   
     /**
@@ -121,13 +125,15 @@ public class DaisyChain {
                              actually finished before the completion handler was called. If the duration of the animation
                              is `0`, this block is performed at the beginning of the next run loop cycle. This parameter
                              may be `NULL`.
+     - returns:              The current DaisyChain instance.
     */
-    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+    @discardableResult public func animate(withDuration duration: TimeInterval, delay: TimeInterval, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) -> DaisyChain {
         performAndWait {
             UIView.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: { finished in
                 self.resume(completion, finished: finished)
             })
         }
+        return self
     }
   
     /**
@@ -160,12 +166,14 @@ public class DaisyChain {
                                          the animations actually finished before the completion handler was called. If the
                                          duration of the animation is `0`,this block is performed at the beginning of the
                                          next run loop cycle. This parameter may be `NULL`.
+     - returns:                          The current DaisyChain instance.
     */
-    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) -> DaisyChain {
         performAndWait {
             UIView.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: { finished -> Void in
                 self.resume(completion, finished: finished)
             })
         }
+        return self
     }
 }

--- a/DaisyChain/DaisyChain.swift
+++ b/DaisyChain/DaisyChain.swift
@@ -168,7 +168,7 @@ public class DaisyChain {
                                          next run loop cycle. This parameter may be `NULL`.
      - returns:                          The current DaisyChain instance.
     */
-    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) -> DaisyChain {
+    @discardableResult public func animate(withDuration duration: TimeInterval, delay: TimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) -> DaisyChain {
         performAndWait {
             UIView.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: { finished -> Void in
                 self.resume(completion, finished: finished)

--- a/DaisyChain/DaisyChain.swift
+++ b/DaisyChain/DaisyChain.swift
@@ -13,159 +13,159 @@ import UIKit
  Responsible for managing the queue of animations and their sequencing.
  */
 public class DaisyChain {
+
+    private let queue: DispatchQueue
+    private var semaphore: DispatchSemaphore
   
-  private let queue: dispatch_queue_t
-  private var semaphore: dispatch_semaphore_t
-  
-  /**
-   A boolean value which allows you to break a chain of execution by setting it to `true`. Setting it back to `false`
-   does not restart the chain of execution.
-   */
-  public var broken: Bool = false
+   /**
+    A boolean value which allows you to break a chain of execution by setting it to `true`. Setting it back to `false`
+    does not restart the chain of execution.
+    */
+    public var broken: Bool = false
   
   // MARK: Init
   
-  /**
-  Initialises and returns a newly allocated DaisyChain object.
+   /**
+    Initialises and returns a newly allocated DaisyChain object.
   
-  - returns: An initialised DaisyChain object.
-  */
-  public init() {
-    queue = dispatch_queue_create(nil, DISPATCH_QUEUE_SERIAL)
-    semaphore = dispatch_semaphore_create(0)
-  }
-  
-  // MARK: Queue Handling
-  
-  /**
-  Performs the block passed in parameter and waits until the DaisyChain is resumed.
-  */
-  private func performAndWait(completion: () -> Void) {
-    dispatch_async(queue) {
-      
-      // If the chain is broken, we do not execute anything
-      if (self.broken) {
-        return;
-      }
-      
-      dispatch_async(dispatch_get_main_queue(), completion)
-      dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER)
+    - returns: An initialised DaisyChain object.
+    */
+    public init() {
+        queue = DispatchQueue(label: "DaisyChain", attributes: [])
+        semaphore = DispatchSemaphore(value: 0)
     }
-  }
   
-  /**
-   Resumes the previously waiting process.
-   */
-  private func resume(completion: ((Bool) -> Void)?, finished: Bool) {
-    completion?(finished)
-    dispatch_semaphore_signal(semaphore)
-  }
+    // MARK: Queue Handling
   
-  // MARK: Animating
-  
-  /**
-  Sequentially animates changes to one or more views using the specified duration.
-  
-  - parameter duration:   The total duration of the animations, measured in seconds. If you  specify a negative value or
-                          `0`, the changes are made without animating them.
-  - parameter animations: A block object containing the changes to commit to the views. This is  where you
-                          programmatically change any animatable properties of the views in your view hierarchy. This
-                          block takes no parameters and has no return value. This parameter must not be `NULL`.
-  */
-  public func animateWithDuration(duration: NSTimeInterval, animations: () -> Void) {
-    performAndWait {
-      UIView.animateWithDuration(duration, animations: animations, completion: { finished -> Void in
-        self.resume(nil, finished: finished)
-      })
+    /**
+     Performs the block passed in parameter and waits until the DaisyChain is resumed.
+    */
+    private func performAndWait(_ completion: @escaping () -> Void) {
+        queue.async {
+
+            // If the chain is broken, we do not execute anything
+            if (self.broken) {
+                return;
+            }
+
+            DispatchQueue.main.async(execute: completion)
+            _ = self.semaphore.wait(timeout: DispatchTime.distantFuture)
+        }
     }
-  }
   
-  /**
-   Sequentially animate changes to one or more views using the specified duration and completion
-   handler.
-   
-   - parameter duration:   The total duration of the animations, measured in seconds. If you specify a negative value or
-                           `0`, the changes are made without animating them.
-   - parameter animations: A block object containing the changes to commit to the views. This is where you 
-                           programmatically change any animatable properties of the views in your view hierarchy. This 
-                           block takes no parameters and has no return value. This parameter must not be `NULL`.
-   - parameter completion: A block object to be executed when the animation sequence ends. This block has no return 
-                           value and takes a single Boolean argument that indicates whether or not the animations 
-                           actually finished before the completion handler was called. If the duration of the animation
-                           is `0`, this block is performed at the beginning of the next run loop cycle. This parameter 
-                           may be `NULL`.
-   */
-  public func animateWithDuration(duration: NSTimeInterval, animations: () -> Void, completion: ((Bool) -> Void)?) {
-    performAndWait {
-      UIView.animateWithDuration(duration, animations: animations, completion: { finished -> Void in
-        self.resume(completion, finished: finished)
-      })
+    /**
+     Resumes the previously waiting process.
+    */
+    private func resume(_ completion: ((Bool) -> Void)?, finished: Bool) {
+        completion?(finished)
+        semaphore.signal()
     }
-  }
   
-  /**
-   Sequentially animate changes to one or more views using the specified duration, delay, options,
-   and completion handler.
-   
-   - parameter duration:   The total duration of the animations, measured in seconds. If you specify a negative value or
-                           `0`, the changes are made without animating them.
-   - parameter delay:      The amount of time (measured in seconds) to wait before beginning the animations. Specify a 
-                           value of `0` to begin the animations immediately.
-   - parameter options:    A mask of options indicating how you want to perform the animations. For a list of valid 
-                           constants, see `UIViewAnimationOptions`.
-   - parameter animations: A block object containing the changes to commit to the views. This is where you 
-                           programmatically change any animatable properties of the views in your view hierarchy. This 
-                           block takes no parameters and has no return value. This parameter must not be `NULL`.
-   - parameter completion: A block object to be executed when the animation sequence ends. This block has no return 
-                           value and takes a single Boolean argument that indicates whether or not the animations 
-                           actually finished before the completion handler was called. If the duration of the animation
-                           is `0`, this block is performed at the beginning of the next run loop cycle. This parameter 
-                           may be `NULL`.
-   */
-  public func animateWithDuration(duration: NSTimeInterval, delay: NSTimeInterval, options: UIViewAnimationOptions, animations: () -> Void, completion: ((Bool) -> Void)?) {
-    performAndWait {
-      UIView.animateWithDuration(duration, delay: delay, options: options, animations: animations, completion: { finished in
-        self.resume(completion, finished: finished)
-      })
-    }
-  }
+    // MARK: Animating
   
-  /**
-   Sequentially performs a view animation using a timing curve corresponding to the motion of a
-   physical spring.
-   
-   - parameter duration:               The total duration of the animations, measured in seconds. If you specify a
-                                       negative value or `0`, the changes are made without animating them.
-   - parameter delay:                  The amount of time (measured in seconds) to wait before beginning the animations.
-                                       Specify a value of `0` to begin the animations immediately.
-   - parameter usingSpringWithDamping: The damping ratio for the spring animation as it approaches its quiescent state.
-   
-                                       To smoothly decelerate the animation without oscillation, use a value of `1`. 
-                                       Employ a damping ratio closer to zero to increase oscillation.
-   - parameter initialSpringVelocity:  The initial spring velocity. For smooth start to the animation, match this value 
-                                       to the view’s velocity as it was prior to attachment.
-   
-                                       A value of `1` corresponds to the total animation distance traversed in one 
-                                       second. For example, if the total animation distance is 200 points and you want 
-                                       the start of the animation to match a view velocity of 100 pt/s, use a value of 
-                                       `0.5`.
-   - parameter options:                A mask of options indicating how you want to perform the animations. For a list 
-                                       of valid constants, see `UIViewAnimationOptions`.
-   - parameter animations:             A block object containing the changes to commit to the views. This is where you 
-                                       programmatically change any animatable properties of the views in your view 
-                                       hierarchy. This block takes no parameters and as no return value. This parameter 
-                                       must not be `NULL`.
-   - parameter completion:             A block object to be executed when the animation sequence ends. This block has no
-                                       return value and takes a single Boolean argument that indicates whether or not
-                                       the animations actually finished before the completion handler was called. If the
-                                       duration of the animation is `0`,this block is performed at the beginning of the
-                                       next run loop cycle. This parameter may be `NULL`.
-   */
-  public func animateWithDuration(duration: NSTimeInterval, delay: NSTimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: () -> Void, completion: ((Bool) -> Void)?) {
-    performAndWait {
-      UIView.animateWithDuration(duration, delay: delay, options: options, animations: animations, completion: { finished -> Void in
-        self.resume(completion, finished: finished)
-      })
+    /**
+     Sequentially animates changes to one or more views using the specified duration.
+  
+     - parameter duration:   The total duration of the animations, measured in seconds. If you  specify a negative value or
+                             `0`, the changes are made without animating them.
+     - parameter animations: A block object containing the changes to commit to the views. This is  where you
+                             programmatically change any animatable properties of the views in your view hierarchy. This
+                             block takes no parameters and has no return value. This parameter must not be `NULL`.
+    */
+    public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void) {
+        performAndWait {
+            UIView.animate(withDuration: duration, animations: animations, completion: { finished -> Void in
+                self.resume(nil, finished: finished)
+            })
+        }
     }
-  }
+  
+    /**
+     Sequentially animate changes to one or more views using the specified duration and completion
+     handler.
+   
+     - parameter duration:   The total duration of the animations, measured in seconds. If you specify a negative value or
+                             `0`, the changes are made without animating them.
+     - parameter animations: A block object containing the changes to commit to the views. This is where you
+                             programmatically change any animatable properties of the views in your view hierarchy. This
+                             block takes no parameters and has no return value. This parameter must not be `NULL`.
+     - parameter completion: A block object to be executed when the animation sequence ends. This block has no return
+                             value and takes a single Boolean argument that indicates whether or not the animations
+                             actually finished before the completion handler was called. If the duration of the animation
+                             is `0`, this block is performed at the beginning of the next run loop cycle. This parameter
+                             may be `NULL`.
+    */
+    public func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+        performAndWait {
+            UIView.animate(withDuration: duration, animations: animations, completion: { finished -> Void in
+                self.resume(completion, finished: finished)
+            })
+        }
+    }
+  
+    /**
+     Sequentially animate changes to one or more views using the specified duration, delay, options,
+     and completion handler.
+   
+     - parameter duration:   The total duration of the animations, measured in seconds. If you specify a negative value or
+                             `0`, the changes are made without animating them.
+     - parameter delay:      The amount of time (measured in seconds) to wait before beginning the animations. Specify a
+                             value of `0` to begin the animations immediately.
+     - parameter options:    A mask of options indicating how you want to perform the animations. For a list of valid
+                             constants, see `UIViewAnimationOptions`.
+     - parameter animations: A block object containing the changes to commit to the views. This is where you
+                             programmatically change any animatable properties of the views in your view hierarchy. This
+                             block takes no parameters and has no return value. This parameter must not be `NULL`.
+     - parameter completion: A block object to be executed when the animation sequence ends. This block has no return
+                             value and takes a single Boolean argument that indicates whether or not the animations
+                             actually finished before the completion handler was called. If the duration of the animation
+                             is `0`, this block is performed at the beginning of the next run loop cycle. This parameter
+                             may be `NULL`.
+    */
+    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+        performAndWait {
+            UIView.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: { finished in
+                self.resume(completion, finished: finished)
+            })
+        }
+    }
+  
+    /**
+     Sequentially performs a view animation using a timing curve corresponding to the motion of a
+     physical spring.
+
+     - parameter duration:               The total duration of the animations, measured in seconds. If you specify a
+                                         negative value or `0`, the changes are made without animating them.
+     - parameter delay:                  The amount of time (measured in seconds) to wait before beginning the animations.
+                                         Specify a value of `0` to begin the animations immediately.
+     - parameter usingSpringWithDamping: The damping ratio for the spring animation as it approaches its quiescent state.
+   
+                                         To smoothly decelerate the animation without oscillation, use a value of `1`.
+                                         Employ a damping ratio closer to zero to increase oscillation.
+     - parameter initialSpringVelocity:  The initial spring velocity. For smooth start to the animation, match this value
+                                         to the view’s velocity as it was prior to attachment.
+   
+                                         A value of `1` corresponds to the total animation distance traversed in one
+                                         second. For example, if the total animation distance is 200 points and you want
+                                         the start of the animation to match a view velocity of 100 pt/s, use a value of
+                                         `0.5`.
+     - parameter options:                A mask of options indicating how you want to perform the animations. For a list
+                                         of valid constants, see `UIViewAnimationOptions`.
+     - parameter animations:             A block object containing the changes to commit to the views. This is where you
+                                         programmatically change any animatable properties of the views in your view
+                                         hierarchy. This block takes no parameters and as no return value. This parameter
+                                         must not be `NULL`.
+     - parameter completion:             A block object to be executed when the animation sequence ends. This block has no
+                                         return value and takes a single Boolean argument that indicates whether or not
+                                         the animations actually finished before the completion handler was called. If the
+                                         duration of the animation is `0`,this block is performed at the beginning of the
+                                         next run loop cycle. This parameter may be `NULL`.
+    */
+    public func animate(withDuration duration: TimeInterval, delay: TimeInterval, usingSpringWithDamping: CGFloat, initialSpringVelocity: CGFloat, options: UIViewAnimationOptions, animations: @escaping () -> Void, completion: ((Bool) -> Void)?) {
+        performAndWait {
+            UIView.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: { finished -> Void in
+                self.resume(completion, finished: finished)
+            })
+        }
+    }
 }

--- a/DaisyChain/DaisyChain.swift
+++ b/DaisyChain/DaisyChain.swift
@@ -31,7 +31,7 @@ public class DaisyChain {
     - returns: An initialised DaisyChain object.
     */
     public init() {
-        queue = DispatchQueue(label: "DaisyChain", attributes: [])
+        queue = DispatchQueue(label: "DaisyChain")
         semaphore = DispatchSemaphore(value: 0)
     }
   

--- a/DaisyChainTests/DaisyChainTests.swift
+++ b/DaisyChainTests/DaisyChainTests.swift
@@ -91,4 +91,58 @@ class DaisyChainTests: XCTestCase {
         XCTAssert(false, "Completion block should not be executed")
     })
   }
+
+  func testSerialAnimationByReturnedInstance() {
+
+     let expectation = self.expectation(description: "Animation Expectations")
+     let view: UIView = UIView()
+     var positions: [CGFloat] = []
+
+     daisyChain.animate(withDuration: 0.1, animations: {
+        view.frame.origin.x = 10
+     }, completion: { _ in
+        positions.append(view.frame.origin.x)
+     }).animate(withDuration: 0.1, animations: {
+        view.frame.origin.x = 20
+     }, completion: { _ in
+        positions.append(view.frame.origin.x)
+     }).animate(withDuration: 0.1, animations: {
+        view.frame.origin.x = 30
+     }, completion: { _ in
+         positions.append(view.frame.origin.x)
+
+         XCTAssert(positions[0] == 10 && positions[1] == 20 && positions[2] == 30, "Animations did not perform serially")
+         expectation.fulfill()
+     })
+
+     waitForExpectations(timeout: 1.0, handler: nil)
+   }
+
+   func testSerialCompletionByReturnedInstance() {
+
+      let expectation = self.expectation(description: "Swift Expectations")
+      var counter: Int = 0
+
+      daisyChain.animate(withDuration: 2.0, animations: {}, completion: { _ in counter += 1 })
+      .animate(withDuration: 1.0, animations: {}, completion: { _ in counter += 1 })
+      .animate(withDuration: 0.5, animations: {}, completion: { _ in counter += 1 })
+      .animate(withDuration: 0.1, animations: {}, completion: { _ in
+          XCTAssert(counter == 3, "Animations did not call completion serially")
+          expectation.fulfill()
+      })
+
+      waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+   func testBreakableChainByReturnedInstance() {
+
+      daisyChain.animate(withDuration: 0.1, animations: {}, completion: nil)
+      .animate(withDuration: 0.1, animations: {}, completion: { _ in
+          self.daisyChain.broken = true
+      }).animate(withDuration: 0.1, animations: {
+          XCTAssert(false, "Animation block should not be executed")
+      }, completion: { _ in
+          XCTAssert(false, "Completion block should not be executed")
+      })
+    }
 }

--- a/DaisyChainTests/DaisyChainTests.swift
+++ b/DaisyChainTests/DaisyChainTests.swift
@@ -24,11 +24,11 @@ class DaisyChainTests: XCTestCase {
   
   func testSerialAnimation() {
     
-    let expectation = expectationWithDescription("Animation Expectations")
+    let expectation = self.expectation(description: "Animation Expectations")
     let view: UIView = UIView()
     var positions: [CGFloat] = []
     
-    daisyChain.animateWithDuration(0.1,
+    daisyChain.animate(withDuration: 0.1,
       animations: {
         view.frame.origin.x = 10
       },
@@ -36,7 +36,7 @@ class DaisyChainTests: XCTestCase {
         positions.append(view.frame.origin.x)
     })
     
-    daisyChain.animateWithDuration(0.1,
+    daisyChain.animate(withDuration: 0.1,
       animations: {
         view.frame.origin.x = 20
       },
@@ -44,7 +44,7 @@ class DaisyChainTests: XCTestCase {
         positions.append(view.frame.origin.x)
     })
     
-    daisyChain.animateWithDuration(0.1,
+    daisyChain.animate(withDuration: 0.1,
       animations: {
         view.frame.origin.x = 30
       },
@@ -55,35 +55,35 @@ class DaisyChainTests: XCTestCase {
         expectation.fulfill()
     })
     
-    waitForExpectationsWithTimeout(1.0, handler: nil)
+    waitForExpectations(timeout: 1.0, handler: nil)
     
   }
   
   func testSerialCompletion() {
     
-    let expectation = expectationWithDescription("Swift Expectations")
+    let expectation = self.expectation(description: "Swift Expectations")
     var counter: Int = 0
     
-    daisyChain.animateWithDuration(2.0, animations: {}, completion: { _ in counter++ })
-    daisyChain.animateWithDuration(1.0, animations: {}, completion: { _ in counter++ })
-    daisyChain.animateWithDuration(0.5, animations: {}, completion: { _ in counter++ })
-    daisyChain.animateWithDuration(0.1, animations: {}, completion: { _ in
+    daisyChain.animate(withDuration: 2.0, animations: {}, completion: { _ in counter += 1 })
+    daisyChain.animate(withDuration: 1.0, animations: {}, completion: { _ in counter += 1 })
+    daisyChain.animate(withDuration: 0.5, animations: {}, completion: { _ in counter += 1 })
+    daisyChain.animate(withDuration: 0.1, animations: {}, completion: { _ in
       XCTAssert(counter == 3, "Animations did not call completion serially")
       expectation.fulfill()
     })
     
-    waitForExpectationsWithTimeout(5.0, handler: nil)
+    waitForExpectations(timeout: 5.0, handler: nil)
   }
   
   func testBreakableChain() {
     
-    daisyChain.animateWithDuration(0.1, animations: {}, completion: nil)
+    daisyChain.animate(withDuration: 0.1, animations: {}, completion: nil)
     
-    daisyChain.animateWithDuration(0.1, animations: {}, completion: { _ in
+    daisyChain.animate(withDuration: 0.1, animations: {}, completion: { _ in
       self.daisyChain.broken = true
     })
     
-    daisyChain.animateWithDuration(0.1,
+    daisyChain.animate(withDuration: 0.1,
       animations: {
         XCTAssert(false, "Animation block should not be executed")
       },

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 DaisyChain
 ----------
 
-**DaisyChain** is a micro framework which makes UIView animations chaining dead simple. It uses the exact same interface you are familiars with.
+**DaisyChain** is a micro framework which makes UIView animations chaining dead simple. It uses the exact same interface you are familiar with.
 
 #### Chaining made simple
 We all have seen or written code which looks like this:
@@ -33,9 +33,9 @@ UIView.animate(withDuration: 0.5, animations: {
 })
 ```
 
-This can go pretty far, it is also know as the *callback hell*. It's not very flexible and hard to read.
+This can go pretty far, it is also known as *callback hell*. It's not very flexible and hard to read.
 
-With **DaisyChain** the above code looks like this:
+With **DaisyChain** we can rewrite that same code like this:
 
 ```swift
 let chain = DaisyChain()
@@ -61,16 +61,16 @@ chain.animate(withDuration: 0.5, animations: {
 })
 ```
 
-As you can the the code looks more flat, it allows you to easy modify orders or add new steps.
+As you can the the code has been flattened, this allows you to easily modify the order of the steps or the addition of new steps.
 
 #### Breakable chains
 
-**DaisyChain** also adds a simple way to break animation sequences, simply set the `broken` property to `yes` to break a chain:
+**DaisyChain** also adds a simple way to break animation sequences, simply set the `broken` property to `true` to break a chain:
 ```swift
 chain.broken = true
 ```
 
-To continue chaining animation, you'll need to put it back to `false` or create a new chain.
+To continue chaining animations, you'll need to change it back to `false` or create a new chain.
 
 #### Setting up with CocoaPods
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ chain.animate(withDuration: 0.5, animations: {
 
 As you can the the code has been flattened, this allows you to easily modify the order of the steps or the addition of new steps.
 
+Or if you would prefer your code to be more succinct:
+
+```swift
+let chain = DaisyChain()
+
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 0.0)
+}).animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 100.0, y: 0.0)
+}).animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 100.0, y: 100.0)
+}).animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 100.0)
+}).animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 0.0)
+})
+```
+
 #### Breakable chains
 
 **DaisyChain** also adds a simple way to break animation sequences, simply set the `broken` property to `true` to break a chain:

--- a/README.md
+++ b/README.md
@@ -12,25 +12,25 @@ DaisyChain
 We all have seen or written code which looks like this:
 
 ```swift
-UIView.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(0.0, 0.0)
-  }) { _ in
-    UIView.animateWithDuration(0.5, animations: {
-      view.center = CGPointMake(100.0, 0.0)
-      }) { _ in
-        UIView.animateWithDuration(0.5, animations: {
-          view.center = CGPointMake(100.0, 100.0)
-          }) { _ in
-            UIView.animateWithDuration(0.5, animations: {
-              view.center = CGPointMake(0.0, 100.0)
-              }) { _ in
-                UIView.animateWithDuration(0.5, animations: {
-                  view.center = CGPointMake(0.0, 0.0)
+UIView.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 0.0)
+}, completion: { _ in
+    UIView.animate(withDuration: 0.5, animations: {
+        view.center = CGPoint(x: 100.0, y: 0.0)
+    }, completion: { _ in
+        UIView.animate(withDuration: 0.5, animations: {
+            view.center = CGPoint(x: 100.0, y: 100.0)
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.5, animations: {
+                view.center = CGPoint(x: 0.0, y: 100.0)
+            }, completion: { _ in
+                UIView.animate(0.5, animations: {
+                    view.center = CGPoint(x: 0.0, y: 0.0)
                 })
-            }
-        }
-    }
-}
+            })
+        })
+    })
+})
 ```
 
 This can go pretty far, it is also know as the *callback hell*. It's not very flexible and hard to read.
@@ -40,24 +40,24 @@ With **DaisyChain** the above code looks like this:
 ```swift
 let chain = DaisyChain()
 
-chain.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(0.0, 0.0)
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 0.0)
 })
 
-chain.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(100.0, 0.0)
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 100.0, y: 0.0)
 })
 
-chain.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(100.0, 100.0)
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 100.0, y: 100.0)
 })
 
-chain.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(0.0, 100.0)
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 100.0)
 })
 
-chain.animateWithDuration(0.5, animations: {
-  view.center = CGPointMake(0.0, 0.0)
+chain.animate(withDuration: 0.5, animations: {
+    view.center = CGPoint(x: 0.0, y: 0.0)
 })
 ```
 


### PR DESCRIPTION
This is a branch off of the swift 4 updated pull request. It adds a return value to all of the animate methods. The return value is the DaisyChain instance. This allows for a simpler syntax if the user prefers. 

i.e.

```swift
let chain = DaisyChain()

chain.animate(withDuration: 0.5, animations: {
    view.center = CGPoint(x: 0.0, y: 0.0)
}).animate(withDuration: 0.5, animations: {
    view.center = CGPoint(x: 100.0, y: 0.0)
}).animate(withDuration: 0.5, animations: {
    view.center = CGPoint(x: 100.0, y: 100.0)
}).animate(withDuration: 0.5, animations: {
    view.center = CGPoint(x: 0.0, y: 100.0)
}).animate(withDuration: 0.5, animations: {
    view.center = CGPoint(x: 0.0, y: 0.0)
})
```

